### PR TITLE
Add epoch to parameters, add methods to transports to provide epoch, sharedrandom

### DIFF
--- a/client/exchange.go
+++ b/client/exchange.go
@@ -510,19 +510,29 @@ func (e *Exchange) processT3Messages() bool {
 // goroutine.
 func (e *Exchange) Run() {
 	defer e.log.Debug("Run was halted.")
+	haltedfn := func() {
+		e.updateChan <- ReunionUpdate{
+			ContactID: e.contactID,
+			Error:     errors.New("Run was halted."),
+		}
+	}
+
 	switch e.status {
 	case initialState:
 		// XXX not required -> 1:A <- DB: fetch current epoch and current set of data for epoch state
 		// 2:A -> DB: transmit א message
 		if !e.sendT1() {
+			defer haltedfn()
 			return
 		}
 		e.status = t1MessageSentState
 		if !e.sentUpdateOK() {
+			defer haltedfn()
 			return
 		}
 		if e.shouldStop() {
 			e.log.Error(ErrShutdown.Error())
+			defer haltedfn()
 			return
 		}
 		fallthrough
@@ -532,15 +542,18 @@ func (e *Exchange) Run() {
 			err := e.fetchState()
 			if err != nil {
 				e.log.Error(err.Error())
+				defer haltedfn()
 				return
 			}
 			// 4:A -> DB: transmit one ב message for each א
 			e.sendT2Messages()
 			if !e.sentUpdateOK() {
+				defer haltedfn()
 				return
 			}
 			if e.shouldStop() {
 				e.log.Error(ErrShutdown.Error())
+				defer haltedfn()
 				return
 			}
 
@@ -549,10 +562,12 @@ func (e *Exchange) Run() {
 			e.sendT3Messages()
 
 			if !e.sentUpdateOK() {
+				defer haltedfn()
 				return
 			}
 			if e.shouldStop() {
 				e.log.Error(ErrShutdown.Error())
+				defer haltedfn()
 				return
 			}
 

--- a/client/exchange_test.go
+++ b/client/exchange_test.go
@@ -57,6 +57,16 @@ func (m *MockReunionDB) Query(command commands.Command) (commands.Command, error
 	return m.server.ProcessQuery(command)
 }
 
+func (m *MockReunionDB) CurrentEpochs() ([]uint64, error) {
+	clock := new(katzenpost.Clock)
+	epoch, _, _ := clock.Now()
+	return []uint64{epoch - 1, epoch, epoch + 1}, nil
+}
+
+func (m *MockReunionDB) CurrentSharedRandoms() ([][]byte, error) {
+	return [][]byte{[]byte{1, 2, 3}, []byte("bbq"), []byte("lol")}, nil
+}
+
 func TestClientServerBasics1(t *testing.T) {
 	require := require.New(t)
 

--- a/crypto/session.go
+++ b/crypto/session.go
@@ -112,6 +112,11 @@ func (c *Session) Epoch() uint64 {
 	return c.epoch
 }
 
+// SharedRandom returns the shared random value.
+func (c *Session) SharedRandom() []byte {
+	return c.sharedRandomValue
+}
+
 // Destroy destroys all the Session's key material
 // and frees up the memory.
 func (c *Session) Destroy() {

--- a/server/state.go
+++ b/server/state.go
@@ -39,6 +39,8 @@ type ReunionDatabase interface {
 	// Query sends a query command to the Reunion DB and returns the
 	// response command or an error.
 	Query(command commands.Command) (commands.Command, error)
+	CurrentSharedRandoms() ([][]byte, error)
+	CurrentEpochs() ([]uint64, error)
 }
 
 // T1Message is used for serializing ReunionState.

--- a/servers/reunion_katzenpost_server/main.go
+++ b/servers/reunion_katzenpost_server/main.go
@@ -38,7 +38,7 @@ import (
 func parametersHandler(response http.ResponseWriter, req *http.Request, clock *katzenpost.Clock) {
 	params := make(cborplugin.Parameters)
 	epoch, _, _ := clock.Now()
-	params["epoch"] = fmt.Sprintf("[%d, %d, %d]", epoch - 1, epoch, epoch + 1)
+	params["epoch"] = fmt.Sprintf("[%d, %d, %d]", epoch-1, epoch, epoch+1)
 	serialized, err := cbor.Marshal(params)
 	if err != nil {
 		panic(err)

--- a/servers/reunion_katzenpost_server/main.go
+++ b/servers/reunion_katzenpost_server/main.go
@@ -35,8 +35,10 @@ import (
 	"gopkg.in/op/go-logging.v1"
 )
 
-func parametersHandler(response http.ResponseWriter, req *http.Request) {
-	params := new(cborplugin.Parameters)
+func parametersHandler(response http.ResponseWriter, req *http.Request, clock *katzenpost.Clock) {
+	params := make(cborplugin.Parameters)
+	epoch, _, _ := clock.Now()
+	params["epoch"] = fmt.Sprintf("[%d, %d, %d]", epoch - 1, epoch, epoch + 1)
 	serialized, err := cbor.Marshal(params)
 	if err != nil {
 		panic(err)
@@ -137,8 +139,11 @@ func main() {
 	_requestHandler := func(response http.ResponseWriter, request *http.Request) {
 		requestHandler(httpLog, reunionServer, response, request)
 	}
+	_parametersHandler := func(response http.ResponseWriter, request *http.Request) {
+		parametersHandler(response, request, clock)
+	}
 	http.HandleFunc("/request", _requestHandler)
-	http.HandleFunc("/parameters", parametersHandler)
+	http.HandleFunc("/parameters", _parametersHandler)
 	fmt.Printf("%s\n", socketFile)
 	httpServer.Serve(unixListener)
 	os.Remove(socketFile)

--- a/transports/http/http_query.go
+++ b/transports/http/http_query.go
@@ -45,10 +45,12 @@ func NewTransport(url string) *Transport {
 }
 
 
+// CurrentSharedRandoms returns the valid shared randoms the transport provides
 func (k *Transport) CurrentSharedRandoms() ([][]byte, error) {
 	return nil, errors.New("NotImplemented")
 }
 
+// CurrentEpochs returns the valid epochs the transport provides
 func (k *Transport) CurrentEpochs() ([]uint64, error) {
 	return nil, errors.New("NotImplemented")
 }

--- a/transports/http/http_query.go
+++ b/transports/http/http_query.go
@@ -19,6 +19,7 @@ package http
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -41,6 +42,15 @@ func NewTransport(url string) *Transport {
 		url:    url,
 		client: &http.Client{Timeout: time.Second * 10},
 	}
+}
+
+
+func (k *Transport) CurrentSharedRandoms() ([][]byte, error) {
+	return nil, errors.New("NotImplemented")
+}
+
+func (k *Transport) CurrentEpochs() ([]uint64, error) {
+	return nil, errors.New("NotImplemented")
 }
 
 // Query sends the command to the destination Reunion DB service over HTTP.

--- a/transports/katzenpost/query.go
+++ b/transports/katzenpost/query.go
@@ -69,19 +69,16 @@ func (k *Transport) CurrentEpochs() ([]uint64, error) {
 	if err != nil {
 		return nil, errors.New("Provider not found in PKI")
 	}
-	ep, ok := p.Kaetzchen[k.Recipient]
-	if !ok {
-		return nil, errors.New("Reunion endpoint not found in PKI")
-	}
-	parm, ok := ep["epoch"]
-	if !ok {
+	if ep, ok := p.Kaetzchen["reunion"]; ok {
+		if parm, ok := ep["epoch"]; ok {
+			if epochs := parmToEpochs(parm.(string)); epochs != nil {
+				return epochs, nil
+			}
+			return nil, errors.New("No valid epochs found in descriptor")
+		}
 		return nil, errors.New("Providers Reunion descriptor il formatted")
 	}
-	epochs := parmToEpochs(parm.(string))
-	if epochs == nil {
-		return nil, errors.New("No valid epochs found in descriptor")
-	}
-	return epochs, nil
+	return nil, errors.New("Reunion endpoint not found in PKI")
 }
 
 // Query sends the command to the destination Reunion DB service

--- a/transports/katzenpost/query.go
+++ b/transports/katzenpost/query.go
@@ -22,6 +22,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/katzenpost/client"
 	"github.com/katzenpost/reunion/commands"
@@ -37,6 +39,49 @@ type Transport struct {
 	Recipient string
 	// Provider is the destination Provider.
 	Provider string
+}
+
+// CurrentSharedRandoms returns the valid SharedRandoms in the PKI
+// but in the future may return a transport specific SharedRandom
+func (k *Transport) CurrentSharedRandoms() ([][]byte, error) {
+	doc := k.Session.CurrentDocument()
+	return doc.PriorSharedRandom, nil
+}
+
+// CurrentEpochs returns the valid Epochs that this service has announced
+func (k *Transport) CurrentEpochs() ([]uint64, error) {
+	parmToEpochs := func(epochstr string) []uint64 {
+		epochsAsc := strings.Split(strings.Trim(epochstr, "[]"), ",")
+		epochs := make([]uint64, 0)
+		for _, e := range epochsAsc {
+			epoch, err := strconv.Atoi(strings.Trim(e, " "))
+			if err != nil {
+				return nil
+			}
+			epochs = append(epochs, uint64(epoch))
+		}
+		return epochs
+	}
+
+	// Verify the service is still advertising valid epochs in the current PKI
+	doc := k.Session.CurrentDocument()
+	p, err := doc.GetProvider(k.Provider)
+	if err != nil {
+		return nil, errors.New("Provider not found in PKI")
+	}
+	ep, ok := p.Kaetzchen[k.Recipient]
+	if !ok {
+		return nil, errors.New("Reunion endpoint not found in PKI")
+	}
+	parm, ok := ep["epoch"]
+	if !ok {
+		return nil, errors.New("Providers Reunion descriptor il formatted")
+	}
+	epochs := parmToEpochs(parm.(string))
+	if epochs == nil {
+		return nil, errors.New("No valid epochs found in descriptor")
+	}
+	return epochs, nil
 }
 
 // Query sends the command to the destination Reunion DB service


### PR DESCRIPTION
this PR facilitates publishing the epoch parameters by adding an epoch parameter that will be included in the consensus (see: https://github.com/katzenpost/server/pull/144, which is needed in order to rotate the epochs each descriptor publication)