### PR TITLE
Decompose test into many test functions for clarity

### DIFF
--- a/primitives/primitives_test.go
+++ b/primitives/primitives_test.go
@@ -4,16 +4,17 @@
 package primitives
 
 import (
-	"testing"
 	"encoding/hex"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/katzenpost/hpqc/nike/schemes"
 )
 
+// ALL the test vectors here are from the python ref.
 
-func TestPrimitivesWithVectors(t *testing.T) {
+func TestHash(t *testing.T) {
 	// blake2b
 	hashIn := []byte("REUNION is for rendezvous")
 	expectedHashOut, err := hex.DecodeString("1ffb4f05cb3e841d44079afbcc51f62edbd7092294edac59846b8519f48c5a45")
@@ -21,12 +22,9 @@ func TestPrimitivesWithVectors(t *testing.T) {
 	hashOut := Hash(hashIn)
 	t.Logf("hashOut %x", hashOut)
 	require.Equal(t, hashOut[:], expectedHashOut[:])
+}
 
-/* test vectors from ref python
-prp_key = bytes.fromhex('37620a87ccc74b5e425164371603bd96c794594b7d07e4887bae6c7f08fa9659')
-prp_msg = bytes.fromhex('5245554e494f4e20697320666f722052656e64657a766f75732e2e2e20505250')
-prp_ct = bytes.fromhex('a74b26c607e56b1f59a84d91ff738e6b55f94ceedc418118347c2b733e5ebe92')
-*/
+func TestPRP(t *testing.T) {
 
 	key, err := hex.DecodeString("37620a87ccc74b5e425164371603bd96c794594b7d07e4887bae6c7f08fa9659")
 	require.NoError(t, err)
@@ -41,7 +39,7 @@ prp_ct = bytes.fromhex('a74b26c607e56b1f59a84d91ff738e6b55f94ceedc418118347c2b73
 	copy(keyArr[:], key)
 	mesgArr := &[32]byte{}
 	copy(mesgArr[:], mesg)
-	
+
 	ciphertext := AeadEcbEncrypt(keyArr, mesgArr)
 	require.Equal(t, ciphertext[:], expectedCiphertext[:])
 
@@ -49,15 +47,9 @@ prp_ct = bytes.fromhex('a74b26c607e56b1f59a84d91ff738e6b55f94ceedc418118347c2b73
 	copy(block[:], ciphertext)
 	plaintext := AeadEcbDecrypt(keyArr, block)
 	require.Equal(t, plaintext[:], mesg[:])
+}
 
-
-/*
-aead_key: bytes = bytes.fromhex('2e845d6aa49d50fd388c9c7072aac817ec71e323a4d32532263a757c98404c8a')
-aead_pt: bytes = bytes.fromhex('5245554e494f4e20697320666f722052656e64657a766f7573')
-aead_ad: bytes = bytes.fromhex('e7bab55e065f23a4cb74ce9e6c02aed0c31c90cce16b3d6ec7c98a3ed65327cf')
-aead_ct: bytes = bytes.fromhex('a405c2d42d576140108a84a08a9c8ee140d5c72c5332ec6713cf7c6fb27719a9007606f7834853245b')
-   
-*/
+func TestAEAD(t *testing.T) {
 	aeadKey, err := hex.DecodeString("2e845d6aa49d50fd388c9c7072aac817ec71e323a4d32532263a757c98404c8a")
 	require.NoError(t, err)
 	aeadMesg, err := hex.DecodeString("5245554e494f4e20697320666f722052656e64657a766f7573")
@@ -72,18 +64,9 @@ aead_ct: bytes = bytes.fromhex('a405c2d42d576140108a84a08a9c8ee140d5c72c5332ec67
 
 	aeadDecrypted := AeadDecrypt(aeadKey, actualCt, aeadAd)
 	require.Equal(t, aeadDecrypted, aeadMesg)
+}
 
-	
-/*
-esk_a_seed = bytes.fromhex('e60498784e625a21d6285ee7a6144a0464dab10120b11f3794dd00e36da98c27')
-esk_a = bytes.fromhex('f988f98f466ff8585598ad12956b385e6090e9fdfdac3ca17c77cad61ac8a430')
-epk_a = bytes.fromhex('b92b89f7bea9d4deee61a07a930edc4f50a7e5eb38a6b5667f44dea5032703f5')
-pk_a = bytes.fromhex('95fa3b2a70e42f4dc66117a02680ddfe45a55451654e7bd685ba2a4179289104')
-esk_b_seed = bytes.fromhex('f50a1248b83f07c6232485508bc889352531a5387b18580d8f6685c352c454d2')
-esk_b = bytes.fromhex('8ba80391df517ee3e3901046adf8c4aab8068cb9a569349e98ee8241b7fde770')
-epk_b = bytes.fromhex('9c1c114b9f11908e6f046805c97a1ba8261e3a3a34cfca9a72d20f3701c553b1')
-pk_b = bytes.fromhex('6d4d5132efddd1ccfdb42178d5cab993617b50a43e24a0b6679e0d6f17ddae1e')
-*/
+func TestElligator(t *testing.T) {
 	seedA := &[KeySize]byte{}
 	rawSeedA, err := hex.DecodeString("e60498784e625a21d6285ee7a6144a0464dab10120b11f3794dd00e36da98c27")
 	require.NoError(t, err)
@@ -135,36 +118,18 @@ pk_b = bytes.fromhex('6d4d5132efddd1ccfdb42178d5cab993617b50a43e24a0b6679e0d6f17
 	ss1 := s.DeriveSecret(privKeyA, pubKey1)
 	ss2 := s.DeriveSecret(privKeyB, pubKey2)
 	require.Equal(t, ss1, ss2)
+}
 
-
-	/*
-argon2i_salt: bytes = DEFAULT_ARGON_SALT
-argon2i_password: bytes = bytes(b'REUNION is for rendezvous')
-argon2i_hash: bytes = bytes.fromhex('131f782cae57faa5055277621aec7c3984fbef048c8d183848f3def2697c7acd')
-	*/
-
+func TestArgon2i(t *testing.T) {
 	argon2Password := []byte("REUNION is for rendezvous")
 	argon2Salt := make([]byte, 32)
-	require.NoError(t, err)
 	argon2ExpectedResult, err := hex.DecodeString("131f782cae57faa5055277621aec7c3984fbef048c8d183848f3def2697c7acd")
 	require.NoError(t, err)
 	argon2Result := Argon2(argon2Password, argon2Salt)
 	require.Equal(t, argon2Result, argon2ExpectedResult)
+}
 
-
-	// hkdf
-	/*
-DEFAULT_ARGON_SALT: bytes = b"\x00" * 32
-hkdf_salt: bytes = DEFAULT_HKDF_SALT
-hkdf_key = bytes.fromhex('513e3c670ab00a436de0d801b07e085149ef205d27807d656253cd9a08a7bdf0')
-hkdf_pdk = bytes.fromhex('9a3b6d37987a9ea05709a9ef2b8c8e4e0b0c51088cb6edc93bcacf4ff36fda1c')
-
-    >>> from reunion.__vectors__ import hkdf_salt, hkdf_key, hkdf_pdk, hkdf_pdk
-    >>> _hkdf_result = hkdf(hkdf_key, hkdf_salt)
-    >>> _hkdf_pdk = _hkdf_result.expand(b'', 32)
-    >>> hkdf_pdk == _hkdf_pdk
-    Trueo
-	*/
+func TestHKDF(t *testing.T) {
 	hkdfKey, err := hex.DecodeString("513e3c670ab00a436de0d801b07e085149ef205d27807d656253cd9a08a7bdf0")
 	require.NoError(t, err)
 	hkdfSalt := make([]byte, 32)
@@ -172,6 +137,4 @@ hkdf_pdk = bytes.fromhex('9a3b6d37987a9ea05709a9ef2b8c8e4e0b0c51088cb6edc93bcacf
 	require.NoError(t, err)
 	hkdfOut := HKDF(hkdfKey, hkdfSalt)
 	require.Equal(t, hkdfOut, hkdfExpected)
-
-
 }

--- a/primitives/primitives_test.go
+++ b/primitives/primitives_test.go
@@ -138,3 +138,15 @@ func TestHKDF(t *testing.T) {
 	hkdfOut := HKDF(hkdfKey, hkdfSalt)
 	require.Equal(t, hkdfOut, hkdfExpected)
 }
+
+func TestCTIDHDeterministicRNG(t *testing.T) {
+	seed, err := hex.DecodeString("163d228fd8182bdb0e259fbf0ed5a776b47126ba4d61d774cce87f6546f8d677")
+	require.NoError(t, err)
+	context := uint64(1)
+
+	detRng := HighCtidhDeterministicRNG(seed)
+	outBuf := make([]byte, 256)
+	detRng(outBuf, context)
+
+	t.Logf("outBuf %x", outBuf)
+}

--- a/session.go
+++ b/session.go
@@ -8,9 +8,33 @@ import (
 // "github.com/katzenpost/hpqc/nike/x25519"
 )
 
+const (
+	alphaLen = 32
+	betaLen  = 128
+	gammaLen = 16
+)
+
 type T1 struct {
-	Alpha [32]byte  // X25519 pub key
-	Beta  [128]byte // CTIDH 1024 pub key
-	Gamme [16]byte  // MAC
-	Delta []byte    // ciphertext
+	Alpha [alphaLen]byte // X25519 pub key
+	Beta  [betaLen]byte  // CTIDH 1024 pub key
+	Gamma [gammaLen]byte // MAC
+	Delta []byte         // ciphertext
+}
+
+func (t *T1) MarshalBinary() (data []byte, err error) {
+	out := []byte{}
+	out = append(out, t.Alpha[:]...)
+	out = append(out, t.Beta[:]...)
+	out = append(out, t.Gamma[:]...)
+	out = append(out, t.Delta...)
+	return out, nil
+}
+
+func (t *T1) UnmarshalBinary(data []byte) error {
+	copy(t.Alpha[:], data[:alphaLen])
+	copy(t.Beta[:], data[alphaLen:alphaLen+betaLen])
+	copy(t.Gamma[:], data[alphaLen+betaLen:alphaLen+betaLen+gammaLen])
+	t.Delta = make([]byte, len(data[alphaLen+betaLen+gammaLen:]))
+	copy(t.Delta[:], data[alphaLen+betaLen+gammaLen:])
+	return nil
 }

--- a/session.go
+++ b/session.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (C) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package reunion
+
+import (
+// "github.com/katzenpost/hpqc/nike/ctidh/ctidh1024"
+// "github.com/katzenpost/hpqc/nike/x25519"
+)
+
+type T1 struct {
+	Alpha [32]byte  // X25519 pub key
+	Beta  [128]byte // CTIDH 1024 pub key
+	Gamme [16]byte  // MAC
+	Delta []byte    // ciphertext
+}

--- a/session.go
+++ b/session.go
@@ -38,3 +38,10 @@ func (t *T1) UnmarshalBinary(data []byte) error {
 	copy(t.Delta[:], data[alphaLen+betaLen+gammaLen:])
 	return nil
 }
+
+type Peer struct{}
+
+type Session struct {
+	Peers   map[[32]byte]*Peer
+	Results []int // XXX fix type, when we learn what it's a list of (e.g. in lean4: List UInt32)
+}


### PR DESCRIPTION
Decompose tests into several functions for clarity.
Add a T1 type and encoding methods.
Add wip peer and session types... 